### PR TITLE
Avoid Panic When Fetching Info Before Bridge is Initialized (#504)

### DIFF
--- a/relays/substrate-client/src/error.rs
+++ b/relays/substrate-client/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
 	Request(RequestError),
 	/// The response from the server could not be SCALE decoded.
 	ResponseParseFailed(codec::Error),
+	/// The Substrate bridge pallet has not yet been initialized.
+	UninitializedBridgePallet,
 	/// Account does not exist on the chain.
 	AccountDoesNotExist,
 	/// Custom logic error.
@@ -70,6 +72,7 @@ impl ToString for Error {
 			Self::WsConnectionError(e) => e.to_string(),
 			Self::Request(e) => e.to_string(),
 			Self::ResponseParseFailed(e) => e.what().to_string(),
+			Self::UninitializedBridgePallet => "The Substrate bridge pallet has not been initialized yet.".into(),
 			Self::AccountDoesNotExist => "Account does not exist on the chain".into(),
 			Self::Custom(e) => e.clone(),
 		}

--- a/relays/substrate/src/headers_target.rs
+++ b/relays/substrate/src/headers_target.rs
@@ -91,13 +91,12 @@ where
 		let decoded_response: Vec<(P::Number, P::Hash)> =
 			Decode::decode(&mut &encoded_response.0[..]).map_err(SubstrateError::ResponseParseFailed)?;
 
-		const WARNING_MSG: &str = "Parsed an empty list of headers, we should always have at least
-									one. Has the bridge pallet been initialized yet?";
-		let best_header = decoded_response
+		// If we parse an empty list of headers it means that bridge pallet has not been initalized
+		// yet. Otherwise we expect to always have at least one header.
+		decoded_response
 			.last()
-			.ok_or_else(|| SubstrateError::ResponseParseFailed(WARNING_MSG.into()))?;
-		let best_header_id = HeaderId(best_header.0, best_header.1);
-		Ok(best_header_id)
+			.ok_or(SubstrateError::UninitializedBridgePallet)
+			.map(|(num, hash)| HeaderId(*num, *hash))
 	}
 
 	async fn is_known_header(&self, id: HeaderIdOf<P>) -> Result<(HeaderIdOf<P>, bool), Self::Error> {


### PR DESCRIPTION
* Allow bridge pallet to return no finalized headers

* Update Runtime APIs to optionally return best finalized header

* Update relay to handle optional best finalized headers

* Fix Clippy lints

* Return a dummy header instead of an Option

* Remove Option from runtime Apis

* Remove support for handling optional finalized headers in relay